### PR TITLE
Android client scheduling updates

### DIFF
--- a/client-android/build.gradle.kts
+++ b/client-android/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.2.0")
     implementation("androidx.work:work-runtime-ktx:2.4.0")
     implementation("ru.cleverpumpkin:crunchycalendar:2.0.0")
+    implementation("ca.antonious:materialdaypicker:0.7.3")
 
     kapt("androidx.room:room-compiler:2.3.0-alpha04")
 

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/notifications/NotificationRepositorySpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/notifications/NotificationRepositorySpec.kt
@@ -8,6 +8,7 @@ import eventually.client.persistence.notifications.NotificationEntity
 import eventually.client.persistence.notifications.NotificationEntityDao
 import eventually.client.persistence.notifications.NotificationRepository
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.test.client.await
 import kotlinx.coroutines.runBlocking
@@ -98,7 +99,7 @@ class NotificationRepositorySpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/notifications/NotificationViewModelSpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/notifications/NotificationViewModelSpec.kt
@@ -8,6 +8,7 @@ import eventually.client.persistence.notifications.NotificationEntity
 import eventually.client.persistence.notifications.NotificationEntityDatabase
 import eventually.client.persistence.notifications.NotificationViewModel
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.test.client.await
 import eventually.test.client.eventually
@@ -146,7 +147,7 @@ class NotificationViewModelSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/schedules/TaskScheduleRepositorySpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/schedules/TaskScheduleRepositorySpec.kt
@@ -8,6 +8,7 @@ import eventually.client.persistence.schedules.TaskScheduleEntity
 import eventually.client.persistence.schedules.TaskScheduleEntityDao
 import eventually.client.persistence.schedules.TaskScheduleRepository
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.core.model.TaskSchedule
 import eventually.test.client.await
@@ -77,7 +78,7 @@ class TaskScheduleRepositorySpec {
             goal = "test-goal",
             schedule = Task.Schedule.Repeating(
                 start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-                every = Duration.ofMinutes(20)
+                every = Duration.ofMinutes(20).toInterval()
             ),
             contextSwitch = Duration.ofMinutes(5),
             isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/schedules/TaskScheduleViewModelSpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/schedules/TaskScheduleViewModelSpec.kt
@@ -8,6 +8,7 @@ import eventually.client.persistence.schedules.TaskScheduleEntity
 import eventually.client.persistence.schedules.TaskScheduleEntityDatabase
 import eventually.client.persistence.schedules.TaskScheduleViewModel
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.core.model.TaskSchedule
 import eventually.test.client.await
@@ -92,7 +93,7 @@ class TaskScheduleViewModelSpec {
             goal = "test-goal",
             schedule = Task.Schedule.Repeating(
                 start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-                every = Duration.ofMinutes(20)
+                every = Duration.ofMinutes(20).toInterval()
             ),
             contextSwitch = Duration.ofMinutes(5),
             isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskEntityDaoSpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskEntityDaoSpec.kt
@@ -9,6 +9,7 @@ import eventually.client.persistence.tasks.TaskEntity
 import eventually.client.persistence.tasks.TaskEntityDao
 import eventually.client.persistence.tasks.TaskEntityDatabase
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.test.client.await
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.equalTo
@@ -69,7 +70,7 @@ class TaskEntityDaoSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskEntityDatabaseSpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskEntityDatabaseSpec.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import eventually.client.persistence.tasks.TaskEntity
 import eventually.client.persistence.tasks.TaskEntityDatabase
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.test.client.await
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.equalTo
@@ -43,7 +44,7 @@ class TaskEntityDatabaseSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskRepositorySpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskRepositorySpec.kt
@@ -8,6 +8,7 @@ import eventually.client.persistence.tasks.TaskEntity
 import eventually.client.persistence.tasks.TaskEntityDao
 import eventually.client.persistence.tasks.TaskRepository
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.test.client.await
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.equalTo
@@ -71,7 +72,7 @@ class TaskRepositorySpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskViewModelSpec.kt
+++ b/client-android/src/androidTest/java/eventually/test/client/persistence/tasks/TaskViewModelSpec.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import eventually.client.persistence.tasks.TaskEntityDatabase
 import eventually.client.persistence.tasks.TaskViewModel
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.test.client.await
 import eventually.test.client.eventually
 import kotlinx.coroutines.runBlocking
@@ -84,7 +85,7 @@ class TaskViewModelSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/main/AndroidManifest.xml
+++ b/client-android/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="eventually.client">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:allowBackup="true"
         android:fullBackupContent="true"
@@ -14,6 +16,20 @@
         <service
             android:name=".scheduling.SchedulerService"
             android:exported="false" />
+
+        <receiver android:name=".activities.receivers.SystemConfigurationChangedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name=".activities.receivers.SystemStartedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name=".activities.NewTaskActivity"

--- a/client-android/src/main/java/eventually/client/activities/helpers/Common.kt
+++ b/client-android/src/main/java/eventually/client/activities/helpers/Common.kt
@@ -5,8 +5,11 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.CharacterStyle
 import eventually.client.R
+import java.time.DayOfWeek
 import java.time.Duration
+import java.time.format.TextStyle
 import java.time.temporal.ChronoUnit
+import java.util.Locale
 
 object Common {
     fun Duration.toFields(): Pair<Int, ChronoUnit> {
@@ -51,6 +54,9 @@ object Common {
         this == context.getString(R.string.duration_plural_seconds) -> ChronoUnit.SECONDS
         else -> throw IllegalArgumentException("Unexpected ChronoUnit string provided: [$this]")
     }
+
+    fun Set<DayOfWeek>.asString(): String =
+        sorted().joinToString(", ") { it.getDisplayName(TextStyle.SHORT, Locale.getDefault()) }
 
     data class StyledString(val placeholder: String, val content: String, val style: CharacterStyle)
 

--- a/client-android/src/main/java/eventually/client/activities/helpers/Common.kt
+++ b/client-android/src/main/java/eventually/client/activities/helpers/Common.kt
@@ -5,8 +5,10 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.CharacterStyle
 import eventually.client.R
+import eventually.core.model.Task
 import java.time.DayOfWeek
 import java.time.Duration
+import java.time.Period
 import java.time.format.TextStyle
 import java.time.temporal.ChronoUnit
 import java.util.Locale
@@ -31,7 +33,24 @@ object Common {
         }
     }
 
+    fun Period.toFields(): Pair<Int, ChronoUnit> {
+        return when {
+            years > 0 -> years to ChronoUnit.YEARS
+            months > 0 -> months to ChronoUnit.MONTHS
+            else -> days to ChronoUnit.DAYS
+        }
+    }
+
+    fun Task.Schedule.Repeating.Interval.toFields(): Pair<Int, ChronoUnit> {
+        return when (this) {
+            is Task.Schedule.Repeating.Interval.DurationInterval -> this.value.toFields()
+            is Task.Schedule.Repeating.Interval.PeriodInterval -> this.value.toFields()
+        }
+    }
+
     fun ChronoUnit.asString(context: Context): String = when {
+        this == ChronoUnit.YEARS -> context.getString(R.string.duration_plural_years)
+        this == ChronoUnit.MONTHS -> context.getString(R.string.duration_plural_months)
         this == ChronoUnit.DAYS -> context.getString(R.string.duration_plural_days)
         this == ChronoUnit.HOURS -> context.getString(R.string.duration_plural_hours)
         this == ChronoUnit.MINUTES -> context.getString(R.string.duration_plural_minutes)
@@ -40,6 +59,8 @@ object Common {
     }
 
     fun ChronoUnit.asQuantityString(amount: Int, context: Context): String = when {
+        this == ChronoUnit.YEARS -> context.resources.getQuantityString(R.plurals.duration_years, amount)
+        this == ChronoUnit.MONTHS -> context.resources.getQuantityString(R.plurals.duration_months, amount)
         this == ChronoUnit.DAYS -> context.resources.getQuantityString(R.plurals.duration_days, amount)
         this == ChronoUnit.HOURS -> context.resources.getQuantityString(R.plurals.duration_hours, amount)
         this == ChronoUnit.MINUTES -> context.resources.getQuantityString(R.plurals.duration_minutes, amount)
@@ -48,6 +69,8 @@ object Common {
     }
 
     fun String.asChronoUnit(context: Context): ChronoUnit = when {
+        this == context.getString(R.string.duration_plural_years) -> ChronoUnit.YEARS
+        this == context.getString(R.string.duration_plural_months) -> ChronoUnit.MONTHS
         this == context.getString(R.string.duration_plural_days) -> ChronoUnit.DAYS
         this == context.getString(R.string.duration_plural_hours) -> ChronoUnit.HOURS
         this == context.getString(R.string.duration_plural_minutes) -> ChronoUnit.MINUTES

--- a/client-android/src/main/java/eventually/client/activities/helpers/TaskDetails.kt
+++ b/client-android/src/main/java/eventually/client/activities/helpers/TaskDetails.kt
@@ -260,7 +260,9 @@ object TaskDetails {
             ChronoUnit.SECONDS,
             ChronoUnit.MINUTES,
             ChronoUnit.HOURS,
-            ChronoUnit.DAYS
+            ChronoUnit.DAYS,
+            ChronoUnit.MONTHS,
+            ChronoUnit.YEARS
         )
     }
 
@@ -362,7 +364,7 @@ object TaskDetails {
                     val durationType = scheduleRepeatingEveryDurationTypeField.editText?.text.toString().asChronoUnit(context)
                     val durationAmount = scheduleRepeatingEveryDurationAmountField.editText?.text.toString().toLong()
 
-                    val every = Duration.of(durationAmount, durationType)
+                    val every = Task.Schedule.Repeating.Interval.of(durationAmount, durationType)
 
                     val days = if (scheduleRepeatingDays.selectedDays.isEmpty()) {
                         Task.Schedule.Repeating.DefaultDays

--- a/client-android/src/main/java/eventually/client/activities/helpers/TaskPreview.kt
+++ b/client-android/src/main/java/eventually/client/activities/helpers/TaskPreview.kt
@@ -19,6 +19,7 @@ import androidx.preference.PreferenceManager
 import eventually.client.R
 import eventually.client.activities.helpers.Common.StyledString
 import eventually.client.activities.helpers.Common.asQuantityString
+import eventually.client.activities.helpers.Common.asString
 import eventually.client.activities.helpers.Common.renderAsSpannable
 import eventually.client.activities.helpers.Common.toFields
 import eventually.client.activities.helpers.DateTimeExtensions.formatAsDate
@@ -72,25 +73,36 @@ object TaskPreview {
             is Task.Schedule.Repeating -> {
                 val start = taskSchedule.start.formatAsTime(this)
                 val every = taskSchedule.every.toFields()
+                val days = taskSchedule.days.asString()
 
-                getString(R.string.task_preview_field_content_schedule_repeating)
-                    .renderAsSpannable(
-                        StyledString(
-                            placeholder = "%1\$s",
-                            content = every.first.toString(),
-                            style = StyleSpan(Typeface.BOLD)
-                        ),
-                        StyledString(
-                            placeholder = "%2\$s",
-                            content = every.second.asQuantityString(every.first, this),
-                            style = StyleSpan(Typeface.BOLD)
-                        ),
-                        StyledString(
-                            placeholder = "%3\$s",
-                            content = start,
-                            style = StyleSpan(Typeface.BOLD)
-                        )
+                getString(
+                    if (taskSchedule.days.size == 7) {
+                        R.string.task_preview_field_content_schedule_repeating_every_day
+                    } else {
+                        R.string.task_preview_field_content_schedule_repeating_on_days
+                    }
+                ).renderAsSpannable(
+                    StyledString(
+                        placeholder = "%1\$s",
+                        content = every.first.toString(),
+                        style = StyleSpan(Typeface.BOLD)
+                    ),
+                    StyledString(
+                        placeholder = "%2\$s",
+                        content = every.second.asQuantityString(every.first, this),
+                        style = StyleSpan(Typeface.BOLD)
+                    ),
+                    StyledString(
+                        placeholder = "%3\$s",
+                        content = start,
+                        style = StyleSpan(Typeface.BOLD)
+                    ),
+                    StyledString(
+                        placeholder = "%4\$s",
+                        content = days,
+                        style = StyleSpan(Typeface.BOLD)
                     )
+                )
             }
             else -> SpannableString("")
         }

--- a/client-android/src/main/java/eventually/client/activities/helpers/TaskPreview.kt
+++ b/client-android/src/main/java/eventually/client/activities/helpers/TaskPreview.kt
@@ -71,7 +71,8 @@ object TaskPreview {
                     )
             }
             is Task.Schedule.Repeating -> {
-                val start = taskSchedule.start.formatAsTime(this)
+                val date = taskSchedule.start.formatAsDate(this)
+                val time = taskSchedule.start.formatAsTime(this)
                 val every = taskSchedule.every.toFields()
                 val days = taskSchedule.days.asString()
 
@@ -84,21 +85,26 @@ object TaskPreview {
                 ).renderAsSpannable(
                     StyledString(
                         placeholder = "%1\$s",
-                        content = every.first.toString(),
+                        content = date,
                         style = StyleSpan(Typeface.BOLD)
                     ),
                     StyledString(
                         placeholder = "%2\$s",
-                        content = every.second.asQuantityString(every.first, this),
+                        content = time,
                         style = StyleSpan(Typeface.BOLD)
                     ),
                     StyledString(
                         placeholder = "%3\$s",
-                        content = start,
+                        content = every.first.toString(),
                         style = StyleSpan(Typeface.BOLD)
                     ),
                     StyledString(
                         placeholder = "%4\$s",
+                        content = every.second.asQuantityString(every.first, this),
+                        style = StyleSpan(Typeface.BOLD)
+                    ),
+                    StyledString(
+                        placeholder = "%5\$s",
                         content = days,
                         style = StyleSpan(Typeface.BOLD)
                     )

--- a/client-android/src/main/java/eventually/client/activities/receivers/SystemConfigurationChangedReceiver.kt
+++ b/client-android/src/main/java/eventually/client/activities/receivers/SystemConfigurationChangedReceiver.kt
@@ -1,0 +1,23 @@
+package eventually.client.activities.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import eventually.client.scheduling.SchedulerService
+
+
+class SystemConfigurationChangedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (
+            intent.action == Intent.ACTION_TIMEZONE_CHANGED
+            || intent.action == Intent.ACTION_TIME_CHANGED
+            || intent.action == Intent.ACTION_LOCALE_CHANGED
+        ) {
+            context.startService(
+                Intent(context, SchedulerService::class.java).apply {
+                    action = SchedulerService.ActionEvaluate
+                }
+            )
+        }
+    }
+}

--- a/client-android/src/main/java/eventually/client/activities/receivers/SystemStartedReceiver.kt
+++ b/client-android/src/main/java/eventually/client/activities/receivers/SystemStartedReceiver.kt
@@ -1,0 +1,16 @@
+package eventually.client.activities.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import eventually.client.scheduling.SchedulerService
+
+class SystemStartedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
+            context.startForegroundService(
+                Intent(context, SchedulerService::class.java)
+            )
+        }
+    }
+}

--- a/client-android/src/main/java/eventually/client/persistence/Converters.kt
+++ b/client-android/src/main/java/eventually/client/persistence/Converters.kt
@@ -10,6 +10,7 @@ import eventually.client.persistence.tasks.TaskEntity
 import eventually.core.model.Task
 import eventually.core.model.TaskInstance
 import eventually.core.model.TaskSchedule
+import java.time.DayOfWeek
 import java.time.Duration
 import java.time.Instant
 import java.util.UUID
@@ -150,6 +151,7 @@ class Converters {
                 json.addProperty("type", "repeating")
                 json.addProperty("start", schedule.start.epochSecond)
                 json.addProperty("every", schedule.every.seconds)
+                json.add("days", JsonArray().apply { schedule.days.forEach { day -> add(day.value) } })
                 json
             }
         }
@@ -169,9 +171,13 @@ class Converters {
                     val every = schedule.get("every")?.asLong
                     require(every != null) { "Expected 'every' field but none was found" }
 
+                    val days = schedule.get("days")?.asJsonArray
+                    require(days != null) { "Expected 'days' field but none was found" }
+
                     Task.Schedule.Repeating(
                         start = Instant.ofEpochSecond(start),
-                        every = Duration.ofSeconds(every)
+                        every = Duration.ofSeconds(every),
+                        days = days.map { day -> DayOfWeek.of(day.asInt) }.toSet()
                     )
                 }
 

--- a/client-android/src/main/res/layout/input_schedule_once.xml
+++ b/client-android/src/main/res/layout/input_schedule_once.xml
@@ -12,30 +12,8 @@
         android:layout_height="wrap_content"
         android:layout_row="0"
         android:layout_column="0"
-        android:orientation="vertical">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/task_details_field_title_schedule_once_time"
-            android:textAppearance="?attr/textAppearanceCaption" />
-
-        <Button
-            android:id="@+id/time"
-            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-            android:layout_width="wrap_content"
-            android:layout_height="59dp"
-            android:layout_marginEnd="4dp"
-            app:strokeColor="@color/input_stroke" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="fill_horizontal"
-        android:layout_row="0"
-        android:layout_column="1"
         android:layout_columnSpan="2"
+        android:layout_gravity="fill_horizontal"
         android:orientation="vertical">
 
         <TextView
@@ -48,6 +26,28 @@
             android:id="@+id/date"
             style="@style/Widget.MaterialComponents.Button.OutlinedButton"
             android:layout_width="match_parent"
+            android:layout_height="59dp"
+            android:layout_marginEnd="4dp"
+            app:strokeColor="@color/input_stroke" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_row="0"
+        android:layout_column="2"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/task_details_field_title_schedule_once_time"
+            android:textAppearance="?attr/textAppearanceCaption" />
+
+        <Button
+            android:id="@+id/time"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="wrap_content"
             android:layout_height="59dp"
             android:layout_marginStart="4dp"
             app:strokeColor="@color/input_stroke" />

--- a/client-android/src/main/res/layout/input_schedule_repeating.xml
+++ b/client-android/src/main/res/layout/input_schedule_repeating.xml
@@ -8,7 +8,7 @@
         android:layout_height="match_parent"
         android:columnCount="3"
         android:orientation="horizontal"
-        android:rowCount="1">
+        android:rowCount="2">
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -44,8 +44,8 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/task_details_field_title_schedule_repeating_every"
                 android:paddingBottom="5.5dp"
+                android:text="@string/task_details_field_title_schedule_repeating_every"
                 android:textAppearance="?attr/textAppearanceCaption" />
 
             <include
@@ -54,6 +54,29 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp" />
+        </LinearLayout>
+
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_row="1"
+            android:layout_column="0"
+            android:layout_columnSpan="3"
+            android:layout_gravity="fill_horizontal"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="5.5dp"
+                android:text="@string/task_details_field_title_schedule_repeating_days"
+                android:textAppearance="?attr/textAppearanceCaption" />
+
+            <ca.antonious.materialdaypicker.MaterialDayPicker
+                android:id="@+id/days"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
         </LinearLayout>
     </GridLayout>
 </layout>

--- a/client-android/src/main/res/layout/input_schedule_repeating.xml
+++ b/client-android/src/main/res/layout/input_schedule_repeating.xml
@@ -8,25 +8,27 @@
         android:layout_height="match_parent"
         android:columnCount="3"
         android:orientation="horizontal"
-        android:rowCount="2">
+        android:rowCount="3">
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="0"
             android:layout_column="0"
+            android:layout_columnSpan="2"
+            android:layout_gravity="fill_horizontal"
             android:orientation="vertical">
 
             <TextView
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/task_details_field_title_schedule_repeating_start"
+                android:text="@string/task_details_field_title_schedule_repeating_start_date"
                 android:textAppearance="?attr/textAppearanceCaption" />
 
             <Button
-                android:id="@+id/start"
+                android:id="@+id/start_date"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="59dp"
                 android:layout_marginEnd="4dp"
                 app:strokeColor="@color/input_stroke" />
@@ -36,8 +38,30 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_row="0"
-            android:layout_column="1"
-            android:layout_columnSpan="2"
+            android:layout_column="2"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/task_details_field_title_schedule_repeating_start_time"
+                android:textAppearance="?attr/textAppearanceCaption" />
+
+            <Button
+                android:id="@+id/start_time"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="59dp"
+                android:layout_marginStart="4dp"
+                app:strokeColor="@color/input_stroke" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_row="1"
+            android:layout_column="0"
+            android:layout_columnSpan="3"
             android:layout_gravity="fill_horizontal"
             android:orientation="vertical">
 
@@ -52,15 +76,14 @@
                 android:id="@+id/every"
                 layout="@layout/input_duration"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp" />
+                android:layout_height="wrap_content" />
         </LinearLayout>
 
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_row="1"
+            android:layout_row="2"
             android:layout_column="0"
             android:layout_columnSpan="3"
             android:layout_gravity="fill_horizontal"

--- a/client-android/src/main/res/values/colors.xml
+++ b/client-android/src/main/res/values/colors.xml
@@ -10,4 +10,9 @@
 
     <color name="button_delete">#B00020</color>
     <color name="button_delete_icon">#FFF</color>
+
+    <!-- day selector colors -->
+    <color name="dayPressed">@color/primary_dark</color>
+    <color name="daySelected">@color/primary</color>
+    <color name="dayDeselected">#BEBEBE</color>
 </resources>

--- a/client-android/src/main/res/values/strings.xml
+++ b/client-android/src/main/res/values/strings.xml
@@ -94,13 +94,13 @@
     <string name="task_list_empty_text">No Tasks</string>
 
     <!-- Task Details -->
-    <string name="task_details_field_title_name">Name</string>
+    <string name="task_details_field_title_name">Name (required)</string>
     <string name="task_details_field_title_name_hint">Task name</string>
-    <string name="task_details_field_title_description">Description</string>
+    <string name="task_details_field_title_description">Description (optional)</string>
     <string name="task_details_field_title_description_hint">Extra task information</string>
-    <string name="task_details_field_title_goal">Goal</string>
+    <string name="task_details_field_title_goal">Goal (required)</string>
     <string name="task_details_field_title_goal_hint">Goal, category or group for the task</string>
-    <string name="task_details_field_title_context_switch">Context Switch</string>
+    <string name="task_details_field_title_context_switch">Context Switch (required)</string>
     <string name="task_details_field_title_is_active">Enabled</string>
     <string name="task_details_field_title_schedule">Schedule</string>
     <string name="task_details_field_title_schedule_once">Once</string>

--- a/client-android/src/main/res/values/strings.xml
+++ b/client-android/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="task_details_field_title_schedule_repeating">Repeating</string>
     <string name="task_details_field_title_schedule_repeating_start">Starting At</string>
     <string name="task_details_field_title_schedule_repeating_every">Every</string>
+    <string name="task_details_field_title_schedule_repeating_days">On</string>
     <string name="task_details_field_error_name">Name cannot be empty</string>
     <string name="task_details_field_error_goal">Goal cannot be empty</string>
     <string name="task_details_field_error_context_switch_duration">Duration cannot be empty or 0</string>
@@ -130,7 +131,8 @@
     <string name="task_preview_field_content_inactive">(disabled)</string>
     <string name="task_preview_field_content_context_switch">%d %s</string>
     <string name="task_preview_field_content_schedule_once">On %1$s at %2$s</string>
-    <string name="task_preview_field_content_schedule_repeating">Every %1$s %2$s starting from %3$s</string>
+    <string name="task_preview_field_content_schedule_repeating_every_day">Every %1$s %2$s starting from %3$s</string>
+    <string name="task_preview_field_content_schedule_repeating_on_days">Every %1$s %2$s starting from %3$s\nOn %4$s</string>
 
     <string name="task_preview_field_content_instance_execution">%s</string>
     <string name="task_preview_field_content_instance_execution_postponed">%s (postponed)</string>

--- a/client-android/src/main/res/values/strings.xml
+++ b/client-android/src/main/res/values/strings.xml
@@ -189,6 +189,14 @@
     <string name="date_time_format_yesterday">Yesterday</string>
     <string name="date_time_format_today">Today</string>
     <string name="date_time_format_tomorrow">Tomorrow</string>
+    <plurals name="duration_years">
+        <item quantity="one">year</item>
+        <item quantity="other">years</item>
+    </plurals>
+    <plurals name="duration_months">
+        <item quantity="one">month</item>
+        <item quantity="other">months</item>
+    </plurals>
     <plurals name="duration_days">
         <item quantity="one">day</item>
         <item quantity="other">days</item>
@@ -205,6 +213,8 @@
         <item quantity="one">second</item>
         <item quantity="other">seconds</item>
     </plurals>
+    <string name="duration_plural_years">years</string>
+    <string name="duration_plural_months">months</string>
     <string name="duration_plural_days">days</string>
     <string name="duration_plural_hours">hours</string>
     <string name="duration_plural_minutes">minutes</string>

--- a/client-android/src/main/res/values/strings.xml
+++ b/client-android/src/main/res/values/strings.xml
@@ -104,10 +104,11 @@
     <string name="task_details_field_title_is_active">Enabled</string>
     <string name="task_details_field_title_schedule">Schedule</string>
     <string name="task_details_field_title_schedule_once">Once</string>
-    <string name="task_details_field_title_schedule_once_time">At</string>
     <string name="task_details_field_title_schedule_once_date">On</string>
+    <string name="task_details_field_title_schedule_once_time">At</string>
     <string name="task_details_field_title_schedule_repeating">Repeating</string>
-    <string name="task_details_field_title_schedule_repeating_start">Starting At</string>
+    <string name="task_details_field_title_schedule_repeating_start_date">Starting From</string>
+    <string name="task_details_field_title_schedule_repeating_start_time">At</string>
     <string name="task_details_field_title_schedule_repeating_every">Every</string>
     <string name="task_details_field_title_schedule_repeating_days">On</string>
     <string name="task_details_field_error_name">Name cannot be empty</string>
@@ -131,8 +132,8 @@
     <string name="task_preview_field_content_inactive">(disabled)</string>
     <string name="task_preview_field_content_context_switch">%d %s</string>
     <string name="task_preview_field_content_schedule_once">On %1$s at %2$s</string>
-    <string name="task_preview_field_content_schedule_repeating_every_day">Every %1$s %2$s starting from %3$s</string>
-    <string name="task_preview_field_content_schedule_repeating_on_days">Every %1$s %2$s starting from %3$s\nOn %4$s</string>
+    <string name="task_preview_field_content_schedule_repeating_every_day">Starting from %1$s at %2$s\nEvery %3$s %4$s</string>
+    <string name="task_preview_field_content_schedule_repeating_on_days">Starting from %1$s at %2$s\nEvery %3$s %4$s\nOn %5$s</string>
 
     <string name="task_preview_field_content_instance_execution">%s</string>
     <string name="task_preview_field_content_instance_execution_postponed">%s (postponed)</string>

--- a/client-android/src/test/java/eventually/test/client/activities/helpers/CommonSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/activities/helpers/CommonSpec.kt
@@ -10,6 +10,7 @@ import eventually.client.activities.helpers.Common.asQuantityString
 import eventually.client.activities.helpers.Common.asString
 import eventually.client.activities.helpers.Common.renderAsSpannable
 import eventually.client.activities.helpers.Common.toFields
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.fail
@@ -19,6 +20,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.time.DayOfWeek
 import java.time.Duration
+import java.time.Period
 import java.time.temporal.ChronoUnit
 
 @RunWith(RobolectricTestRunner::class)
@@ -49,9 +51,30 @@ class CommonSpec {
     }
 
     @Test
+    fun convertPeriodsToFields() {
+        assertThat(Period.ofDays(0).toFields(), equalTo(Pair(0, ChronoUnit.DAYS)))
+        assertThat(Period.ofDays(1).toFields(), equalTo(Pair(1, ChronoUnit.DAYS)))
+        assertThat(Period.ofDays(60).toFields(), equalTo(Pair(60, ChronoUnit.DAYS)))
+
+        assertThat(Period.ofMonths(1).toFields(), equalTo(Pair(1, ChronoUnit.MONTHS)))
+        assertThat(Period.ofMonths(60).toFields(), equalTo(Pair(60, ChronoUnit.MONTHS)))
+
+        assertThat(Period.ofYears(1).toFields(), equalTo(Pair(1, ChronoUnit.YEARS)))
+        assertThat(Period.ofYears(60).toFields(), equalTo(Pair(60, ChronoUnit.YEARS)))
+    }
+
+    @Test
+    fun convertIntervalsToFields() {
+        assertThat(Duration.ofSeconds(21).toInterval().toFields(), equalTo(Pair(21, ChronoUnit.SECONDS)))
+        assertThat(Period.ofMonths(42).toInterval().toFields(), equalTo(Pair(42, ChronoUnit.MONTHS)))
+    }
+
+    @Test
     fun convertChronoUnitsToStrings() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
+        assertThat(ChronoUnit.YEARS.asString(context), equalTo("years"))
+        assertThat(ChronoUnit.MONTHS.asString(context), equalTo("months"))
         assertThat(ChronoUnit.DAYS.asString(context), equalTo("days"))
         assertThat(ChronoUnit.HOURS.asString(context), equalTo("hours"))
         assertThat(ChronoUnit.MINUTES.asString(context), equalTo("minutes"))
@@ -69,6 +92,10 @@ class CommonSpec {
     fun convertChronoUnitsToQualifiedStrings() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
+        assertThat(ChronoUnit.YEARS.asQuantityString(amount = 1, context), equalTo("year"))
+        assertThat(ChronoUnit.YEARS.asQuantityString(amount = 10, context), equalTo("years"))
+        assertThat(ChronoUnit.MONTHS.asQuantityString(amount = 1, context), equalTo("month"))
+        assertThat(ChronoUnit.MONTHS.asQuantityString(amount = 10, context), equalTo("months"))
         assertThat(ChronoUnit.DAYS.asQuantityString(amount = 1, context), equalTo("day"))
         assertThat(ChronoUnit.DAYS.asQuantityString(amount = 10, context), equalTo("days"))
         assertThat(ChronoUnit.HOURS.asQuantityString(amount = 1, context), equalTo("hour"))
@@ -90,6 +117,8 @@ class CommonSpec {
     fun convertStringsToChronoUnits() {
         val context = ApplicationProvider.getApplicationContext<Context>()
 
+        assertThat("years".asChronoUnit(context), equalTo(ChronoUnit.YEARS))
+        assertThat("months".asChronoUnit(context), equalTo(ChronoUnit.MONTHS))
         assertThat("days".asChronoUnit(context), equalTo(ChronoUnit.DAYS))
         assertThat("hours".asChronoUnit(context), equalTo(ChronoUnit.HOURS))
         assertThat("minutes".asChronoUnit(context), equalTo(ChronoUnit.MINUTES))

--- a/client-android/src/test/java/eventually/test/client/activities/helpers/CommonSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/activities/helpers/CommonSpec.kt
@@ -17,6 +17,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.time.DayOfWeek
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
@@ -100,6 +101,16 @@ class CommonSpec {
         } catch (e: java.lang.IllegalArgumentException) {
             assertThat(e.message, equalTo("Unexpected ChronoUnit string provided: [other]"))
         }
+    }
+
+    @Test
+    fun convertDaysOfTheWeekToStrings() {
+        val someDays = setOf(DayOfWeek.TUESDAY, DayOfWeek.SUNDAY, DayOfWeek.FRIDAY, DayOfWeek.SATURDAY)
+        val allDays = someDays + setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY)
+
+        assertThat(someDays.asString(), equalTo("Tue, Fri, Sat, Sun"))
+        assertThat(allDays.asString(), equalTo("Mon, Tue, Wed, Thu, Fri, Sat, Sun"))
+        assertThat(emptySet<DayOfWeek>().asString(), equalTo(""))
     }
 
     @Test

--- a/client-android/src/test/java/eventually/test/client/activities/helpers/TaskManagementSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/activities/helpers/TaskManagementSpec.kt
@@ -9,6 +9,7 @@ import eventually.client.serialization.Extras.requireInstanceId
 import eventually.client.serialization.Extras.requireTask
 import eventually.client.serialization.Extras.requireTaskId
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -116,7 +117,7 @@ class TaskManagementSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = Instant.now().truncatedTo(ChronoUnit.SECONDS),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/test/java/eventually/test/client/activities/receivers/SystemConfigurationChangedReceiverSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/activities/receivers/SystemConfigurationChangedReceiverSpec.kt
@@ -1,0 +1,79 @@
+package eventually.test.client.activities.receivers
+
+import android.content.Context
+import android.content.Intent
+import eventually.client.activities.receivers.SystemConfigurationChangedReceiver
+import eventually.client.scheduling.SchedulerService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Config.OLDEST_SDK])
+class SystemConfigurationChangedReceiverSpec {
+    @Test
+    fun forceScheduleEvaluationOnTimeZoneChange() {
+        val intent = slot<Intent>()
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "test"
+        every { context.startService(capture(intent)) } returns null
+
+        val receiver = SystemConfigurationChangedReceiver()
+        receiver.onReceive(
+            context,
+            Intent(context, SystemConfigurationChangedReceiver::class.java).apply {
+                action = Intent.ACTION_TIMEZONE_CHANGED
+            }
+        )
+
+        assertThat(intent.captured.component?.className, equalTo(SchedulerService::class.java.name))
+        assertThat(intent.captured.action, equalTo(SchedulerService.ActionEvaluate))
+    }
+
+    @Test
+    fun forceScheduleEvaluationOnTimeChange() {
+        val intent = slot<Intent>()
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "test"
+        every { context.startService(capture(intent)) } returns null
+
+        val receiver = SystemConfigurationChangedReceiver()
+        receiver.onReceive(
+            context,
+            Intent(context, SystemConfigurationChangedReceiver::class.java).apply {
+                action = Intent.ACTION_TIME_CHANGED
+            }
+        )
+
+        assertThat(intent.captured.component?.className, equalTo(SchedulerService::class.java.name))
+        assertThat(intent.captured.action, equalTo(SchedulerService.ActionEvaluate))
+    }
+
+    @Test
+    fun forceScheduleEvaluationOnLocaleChange() {
+        val intent = slot<Intent>()
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "test"
+        every { context.startService(capture(intent)) } returns null
+
+        val receiver = SystemConfigurationChangedReceiver()
+        receiver.onReceive(
+            context,
+            Intent(context, SystemConfigurationChangedReceiver::class.java).apply {
+                action = Intent.ACTION_LOCALE_CHANGED
+            }
+        )
+
+        assertThat(intent.captured.component?.className, equalTo(SchedulerService::class.java.name))
+        assertThat(intent.captured.action, equalTo(SchedulerService.ActionEvaluate))
+    }
+}

--- a/client-android/src/test/java/eventually/test/client/activities/receivers/SystemStartedReceiverSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/activities/receivers/SystemStartedReceiverSpec.kt
@@ -1,0 +1,39 @@
+package eventually.test.client.activities.receivers
+
+import android.content.Context
+import android.content.Intent
+import eventually.client.activities.receivers.SystemStartedReceiver
+import eventually.client.scheduling.SchedulerService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Config.OLDEST_SDK])
+class SystemStartedReceiverSpec {
+    @Test
+    fun startSchedulerServiceOnBoot() {
+        val intent = slot<Intent>()
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "test"
+        every { context.startForegroundService(capture(intent)) } returns null
+
+        val receiver = SystemStartedReceiver()
+        receiver.onReceive(
+            context,
+            Intent(context, SystemStartedReceiver::class.java).apply {
+                action = Intent.ACTION_BOOT_COMPLETED
+            }
+        )
+
+        assertThat(intent.captured.component?.className, equalTo(SchedulerService::class.java.name))
+        assertThat(intent.captured.action, equalTo(null))
+    }
+}

--- a/client-android/src/test/java/eventually/test/client/persistence/ConvertersSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/persistence/ConvertersSpec.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.time.DayOfWeek
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -55,8 +56,15 @@ class ConvertersSpec {
         val convertedOnce = converters.scheduleToString(originalOnce)
         val convertedRepeating = converters.scheduleToString(originalRepeating)
 
-        assertThat(convertedOnce, equalTo("""{"type":"once","instant":$instantSeconds}"""))
-        assertThat(convertedRepeating, equalTo("""{"type":"repeating","start":$startSeconds,"every":$durationSeconds}"""))
+        assertThat(
+            convertedOnce,
+            equalTo("""{"type":"once","instant":$instantSeconds}""")
+        )
+
+        assertThat(
+            convertedRepeating,
+            equalTo("""{"type":"repeating","start":$startSeconds,"every":$durationSeconds,"days":[1,2,3,4,5,6,7]}""")
+        )
 
         assertThat(converters.stringToSchedule(convertedOnce), equalTo(originalOnce))
         assertThat(converters.stringToSchedule(convertedRepeating), equalTo(originalRepeating))
@@ -180,7 +188,8 @@ class ConvertersSpec {
             goal = "test-goal",
             schedule = Task.Schedule.Repeating(
                 start = start,
-                every = Duration.ofMinutes(20)
+                every = Duration.ofMinutes(20),
+                days = setOf(DayOfWeek.THURSDAY, DayOfWeek.SATURDAY, DayOfWeek.WEDNESDAY)
             ),
             contextSwitch = Duration.ofMinutes(5),
             isActive = true
@@ -195,7 +204,7 @@ class ConvertersSpec {
                 "name":"test-task",
                 "description":"test-description",
                 "goal":"test-goal",
-                "schedule":{"type":"repeating","start":${start.epochSecond},"every":1200},
+                "schedule":{"type":"repeating","start":${start.epochSecond},"every":1200,"days":[4,6,3]},
                 "context_switch":300,
                 "is_active":true
             }""".replace("\n", "").replace(" ", "")

--- a/client-android/src/test/java/eventually/test/client/scheduling/NotificationManagerExtensionsSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/scheduling/NotificationManagerExtensionsSpec.kt
@@ -11,6 +11,7 @@ import eventually.client.scheduling.NotificationManagerExtensions.deleteInstance
 import eventually.client.scheduling.NotificationManagerExtensions.putInstanceContextSwitchNotification
 import eventually.client.scheduling.NotificationManagerExtensions.putInstanceExecutionNotification
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -123,7 +124,7 @@ class NotificationManagerExtensionsSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/test/java/eventually/test/client/scheduling/NotificationQueueSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/scheduling/NotificationQueueSpec.kt
@@ -9,6 +9,7 @@ import eventually.client.persistence.notifications.NotificationEntity
 import eventually.client.persistence.notifications.NotificationViewModel
 import eventually.client.scheduling.NotificationQueue
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.core.scheduling.SchedulerOps
 import io.mockk.confirmVerified
@@ -258,7 +259,7 @@ class NotificationQueueSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = Instant.now().truncatedTo(ChronoUnit.SECONDS),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/test/java/eventually/test/client/scheduling/SchedulerServiceSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/scheduling/SchedulerServiceSpec.kt
@@ -16,6 +16,7 @@ import eventually.client.serialization.Extras.putInstanceId
 import eventually.client.serialization.Extras.putTask
 import eventually.client.serialization.Extras.putTaskId
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.core.model.TaskSchedule
 import eventually.core.model.TaskSummary
@@ -263,7 +264,7 @@ class SchedulerServiceSpec {
         goal = "test-goal",
         schedule = Task.Schedule.Repeating(
             start = Instant.now().truncatedTo(ChronoUnit.SECONDS),
-            every = Duration.ofMinutes(20)
+            every = Duration.ofMinutes(20).toInterval()
         ),
         contextSwitch = Duration.ofMinutes(5),
         isActive = true

--- a/client-android/src/test/java/eventually/test/client/serialization/ExtrasSpec.kt
+++ b/client-android/src/test/java/eventually/test/client/serialization/ExtrasSpec.kt
@@ -10,6 +10,7 @@ import eventually.client.serialization.Extras.requireInstanceId
 import eventually.client.serialization.Extras.requireTask
 import eventually.client.serialization.Extras.requireTaskId
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -37,7 +38,7 @@ class ExtrasSpec {
             goal = "test-goal",
             schedule = Task.Schedule.Repeating(
                 start = LocalTime.of(0, 15).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-                every = Duration.ofMinutes(20)
+                every = Duration.ofMinutes(20).toInterval()
             ),
             contextSwitch = Duration.ofMinutes(5),
             isActive = true

--- a/core/src/main/kotlin/eventually/core/model/Task.kt
+++ b/core/src/main/kotlin/eventually/core/model/Task.kt
@@ -3,7 +3,11 @@ package eventually.core.model
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.Instant
+import java.time.Period
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAmount
+import java.time.temporal.TemporalUnit
 
 data class Task(
     val id: Int,
@@ -23,7 +27,7 @@ data class Task(
 
         data class Repeating(
             val start: Instant,
-            val every: Duration,
+            val every: Interval,
             val days: Set<DayOfWeek>
         ) : Schedule() {
             override fun next(after: Instant, within: Duration): List<Instant> {
@@ -50,12 +54,53 @@ data class Task(
                 return collect(from = instants.iterator(), collected = emptyList())
             }
 
-            private fun scheduleInstants(step: Duration): Sequence<Instant> = sequence {
+            private fun scheduleInstants(step: Interval): Sequence<Instant> = sequence {
+                val zone = ZoneId.systemDefault()
                 var lastInstant = start
 
                 while (true) {
                     yield(lastInstant)
-                    lastInstant += step
+                    lastInstant = (lastInstant.atZone(zone).plus(step.amount())).toInstant()
+                }
+            }
+
+            sealed class Interval {
+                abstract fun amount(): TemporalAmount
+
+                data class DurationInterval(val value: Duration) : Interval() {
+                    override fun amount(): TemporalAmount = value
+                }
+
+                data class PeriodInterval(val value: Period) : Interval() {
+                    init {
+                        val daysSet = value.days > 0 && value.months == 0 && value.years == 0
+                        val monthsSet = value.months > 0 && value.days == 0 && value.years == 0
+                        val yearsSet = value.years > 0 && value.days == 0 && value.months == 0
+
+                        require(daysSet || monthsSet || yearsSet) {
+                            "Unexpected period found - " +
+                                    "with days: [${value.days > 0}], " +
+                                    "with months: [${value.months > 0}], " +
+                                    "with years: [${value.years > 0}]; " +
+                                    "setting only either days, months or years is allowed"
+                        }
+                    }
+
+                    override fun amount(): TemporalAmount = value
+                }
+
+                companion object {
+                    fun of(amount: Long, unit: TemporalUnit): Interval =
+                        when (unit) {
+                            ChronoUnit.YEARS -> PeriodInterval(Period.ofYears(amount.toInt()))
+                            ChronoUnit.MONTHS -> PeriodInterval(Period.ofMonths(amount.toInt()))
+                            ChronoUnit.DAYS -> PeriodInterval(Period.ofDays(amount.toInt()))
+                            else -> DurationInterval(Duration.of(amount, unit))
+                        }
+
+                    fun Duration.toInterval(): Interval = DurationInterval(value = this)
+
+                    fun Period.toInterval(): Interval = PeriodInterval(value = this)
                 }
             }
 
@@ -70,7 +115,7 @@ data class Task(
                     DayOfWeek.SUNDAY
                 )
 
-                operator fun invoke(start: Instant, every: Duration): Repeating =
+                operator fun invoke(start: Instant, every: Interval): Repeating =
                     Repeating(
                         start = start,
                         every = every,

--- a/core/src/test/kotlin/eventually/test/core/model/TaskScheduleSpec.kt
+++ b/core/src/test/kotlin/eventually/test/core/model/TaskScheduleSpec.kt
@@ -1,6 +1,7 @@
 package eventually.test.core.model
 
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskSchedule
 import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
@@ -24,7 +25,7 @@ class TaskScheduleSpec : WordSpec({
             goal = "test-goal",
             schedule = Task.Schedule.Repeating(
                 start = LocalTime.of(0, 5).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-                every = Duration.ofMinutes(20)
+                every = Duration.ofMinutes(20).toInterval()
             ),
             contextSwitch = Duration.ofMinutes(5),
             isActive = true
@@ -147,7 +148,9 @@ class TaskScheduleSpec : WordSpec({
                 null -> fail("Expected next task instance but none found")
                 else -> {
                     val every = (task.schedule as Task.Schedule.Repeating).every
-                    next.first.instant shouldBe (instance.instant.plus(every.multipliedBy(3)))
+                    val duration = (every as Task.Schedule.Repeating.Interval.DurationInterval).value
+
+                    next.first.instant shouldBe (instance.instant.plus(duration.multipliedBy(3)))
                     next.second.isAfter(after) shouldBe (true)
                 }
             }
@@ -262,7 +265,7 @@ class TaskScheduleSpec : WordSpec({
             val updatedTask = task.copy(
                 schedule = Task.Schedule.Repeating(
                     start = LocalTime.of(0, 5).atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-                    every = Duration.ofMinutes(21)
+                    every = Duration.ofMinutes(21).toInterval()
                 )
             )
 

--- a/core/src/test/kotlin/eventually/test/core/model/TaskSpec.kt
+++ b/core/src/test/kotlin/eventually/test/core/model/TaskSpec.kt
@@ -9,6 +9,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import kotlin.math.abs
 
@@ -26,7 +27,7 @@ class TaskSpec : WordSpec({
 
         "support scheduling repeating events" {
             fun verify(hour: Int, minute: Int, duration: Long) {
-                val now = Instant.now()
+                val now = Instant.now().truncatedTo(ChronoUnit.MINUTES)
                 val within = Duration.ofMinutes(5)
 
                 val originalTime = LocalTime.of(hour, minute)
@@ -41,15 +42,13 @@ class TaskSpec : WordSpec({
 
                 val futureSchedule = Task.Schedule.Repeating(
                     start = originalTime.atDate(LocalDate.now()).toInstant(ZoneOffset.UTC),
-                    every = repetitionDuration
+                    every = repetitionDuration,
+                    days = Task.Schedule.Repeating.DefaultDays
                 )
-
-                val expected = (within.toMinutes() / duration).coerceAtLeast(1L).toInt()
 
                 if (originalSchedule.isAfter(now)) {
                     val next = futureSchedule.next(after = now, within = within)
 
-                    next.size shouldBe (expected)
                     next.first() shouldBe (originalSchedule)
                     next.withIndex().forEach { (i, instant) ->
                         instant shouldBe originalSchedule.plusSeconds(repetitionDuration.seconds * i)
@@ -57,7 +56,6 @@ class TaskSpec : WordSpec({
                 } else {
                     val next = futureSchedule.next(after = now, within = within)
 
-                    next.size shouldBe (expected)
                     next.first() shouldBe (expectedNext)
                     next.withIndex().forEach { (i, instant) ->
                         instant shouldBe expectedNext.plusSeconds(repetitionDuration.seconds * i)
@@ -68,12 +66,37 @@ class TaskSpec : WordSpec({
             for (hour in 0..23) {
                 for (minute in 0..59) {
                     for (duration in 1..120L) {
-                        withClue("Initial schedule: [$hour:$minute]; Duration: [$duration]") {
+                        withClue("Initial schedule at [$hour:$minute] with duration of [$duration] minutes") {
                             verify(hour = hour, minute = minute, duration = duration)
                         }
                     }
                 }
             }
+        }
+
+        "support scheduling repeating events on specific days only" {
+            val today = ZonedDateTime.now()
+            val tomorrow = today.plusDays(1)
+
+            val duration = Duration.ofDays(1)
+            val within = Duration.ofDays(7)
+
+            val schedule = Task.Schedule.Repeating(
+                start = today.toInstant(),
+                every = duration,
+                days = setOf(
+                    today.dayOfWeek,
+                    tomorrow.dayOfWeek
+                )
+            )
+
+            val expected = 2
+
+            val next = schedule.next(after = schedule.start, within = within)
+
+            next.size shouldBe (expected)
+            next.first() shouldBe (tomorrow.toInstant())
+            next.last() shouldBe (today.plusWeeks(1).toInstant())
         }
     }
 })

--- a/core/src/test/kotlin/eventually/test/core/scheduling/SchedulerOpsSpec.kt
+++ b/core/src/test/kotlin/eventually/test/core/scheduling/SchedulerOpsSpec.kt
@@ -1,6 +1,7 @@
 package eventually.test.core.scheduling
 
 import eventually.core.model.Task
+import eventually.core.model.Task.Schedule.Repeating.Interval.Companion.toInterval
 import eventually.core.model.TaskInstance
 import eventually.core.model.TaskSchedule
 import eventually.core.model.TaskSummaryConfig
@@ -43,7 +44,7 @@ class SchedulerOpsSpec : WordSpec({
             val disabledTask = task.copy(id = 4, isActive = false)
             val repeatingTask = task.copy(
                 id = 5,
-                schedule = Task.Schedule.Repeating(start = now, every = Duration.ofMinutes(5)),
+                schedule = Task.Schedule.Repeating(start = now, every = Duration.ofMinutes(5).toInterval()),
                 contextSwitch = config.summarySize
             )
 


### PR DESCRIPTION
* Add day selector control for repeating schedules
* Add date picker control for repeating schedules
* Add support for periods and durations to repeating schedules
* Add support for starting the scheduler after boot and updating schedules after system config change